### PR TITLE
Improved egif_lib coverage by extending the gif encoder test harness

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -135,9 +135,6 @@ rm -rf $WORK/msan
 # Pull trunk libfuzzer.
 cd $SRC && svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer
 
-# Copy DataFlow scripts for collecting and merging the traces.
-cp libfuzzer/scripts/*_data_flow.py /usr/local/bin/
-
 # Cleanup
 rm -rf $SRC/llvm
 rm -rf $SRC/chromium_tools

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -49,7 +49,7 @@ cd clang
 
 OUR_LLVM_REVISION=359254  # For manual bumping.
 FORCE_OUR_REVISION=0  # To allow for manual downgrades.
-LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K\d+(?=')" scripts/update.py)
+LLVM_REVISION=$(grep -Po "CLANG_SVN_REVISION = '\K\d+(?=')" scripts/update.py)
 
 if [ $OUR_LLVM_REVISION -gt $LLVM_REVISION ] || [ $FORCE_OUR_REVISION -ne 0 ]; then
   LLVM_REVISION=$OUR_LLVM_REVISION

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -79,7 +79,10 @@ function check_engine {
       echo "BAD BUILD: $FUZZER seems to have only partial coverage instrumentation."
     fi
   elif [[ "$FUZZING_ENGINE" == afl ]]; then
-    AFL_NO_UI=1 SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
+    # TODO(https://github.com/google/oss-fuzz/issues/2470): Dont use
+    # AFL_DRIVER_DONT_DEFER by default, support .options files in
+    # bad_build_check instead.
+    AFL_DRIVER_DONT_DEFER=1 AFL_NO_UI=1 SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
     CHECK_PASSED=$(egrep "All set and ready to roll" -c $FUZZER_OUTPUT)
     if (( $CHECK_PASSED == 0 )); then
       echo "BAD BUILD: fuzzing $FUZZER with afl-fuzz failed."
@@ -103,7 +106,10 @@ function check_startup_crash {
     $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
     CHECK_PASSED=$(egrep "Done $MIN_NUMBER_OF_RUNS runs" -c $FUZZER_OUTPUT)
   elif [[ "$FUZZING_ENGINE" = afl ]]; then
-    AFL_NO_UI=1 SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
+    # TODO(https://github.com/google/oss-fuzz/issues/2470): Dont use
+    # AFL_DRIVER_DONT_DEFER by default, support .options files in
+    # bad_build_check instead.
+    AFL_DRIVER_DONT_DEFER=1 AFL_NO_UI=1 SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
     if [ $(egrep "target binary (crashed|terminated)" -c $FUZZER_OUTPUT) -eq 0 ]; then
       CHECK_PASSED=1
     fi

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -118,7 +118,7 @@ if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "$ALLOWED_BROKEN_TARGETS_PERCENTAGE" ]; th
 
   # TODO: figure out how to not fail the "special" cases handled below. Those
   # are from "example" and "c-ares" projects and are too small targets to pass.
-  if [ "$(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer $OUT/checksum_fuzzer $OUT/xmltest 2>/dev/null | wc -l)" -gt "0" ]; then
+  if [ "$(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer $OUT/checksum_fuzzer $OUT/xmltest $OUT/fuzz_compression_sas_rle 2>/dev/null | wc -l)" -gt "0" ]; then
     exit 0
   fi
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -523,6 +523,9 @@ def _get_fuzz_targets(project_name):
   """Return names of fuzz targest build in the project's /out directory."""
   fuzz_targets = []
   for name in os.listdir(_get_output_dir(project_name)):
+    if name.startswith('afl-'):
+      continue
+
     path = os.path.join(_get_output_dir(project_name), name)
     if os.path.isfile(path) and os.access(path, os.X_OK):
       fuzz_targets.append(name)

--- a/projects/aosp/project.yaml
+++ b/projects/aosp/project.yaml
@@ -2,3 +2,4 @@ homepage: "https://source.android.com/"
 primary_contact: "android-oss-fuzz@google.com"
 auto_ccs:
    - "kcc@google.com"
+disabled: True

--- a/projects/dav1d/build.sh
+++ b/projects/dav1d/build.sh
@@ -33,7 +33,7 @@ fi
 
 meson -Dbuild_asm=$BUILD_ASM -Dbuild_tools=false -Dfuzzing_engine=oss-fuzz \
       -Db_lundef=false -Ddefault_library=static -Dbuildtype=debugoptimized \
-      -Dlogging=false \
+      -Dlogging=false -Dfuzzer_ldflags=$LIB_FUZZING_ENGINE \
       ${build}
 ninja -j $(nproc) -C ${build}
 

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake libtool
 RUN git clone --depth 1 https://github.com/catenacyber/elliptic-curve-differential-fuzzer.git ecfuzzer
-RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
+RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/ANSSI-FR/libecc.git libecc
 RUN git clone --depth 1 https://github.com/openssl/openssl.git openssl
 ADD https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.32.tar.bz2 libgpg-error-1.32.tar.bz2

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -88,4 +88,4 @@ $CC $CFLAGS -I. -I../gcrypt/src -c modules/gcrypt.c -o gcrypt.o
 $CXX $CXXFLAGS -I. -I../ -c modules/cryptopp.cpp -o cryptopp.o
 $CC $CFLAGS -I. -I../ -c modules/nettle.c -o nettle.o
 
-$CXX $CXXFLAGS fuzz_ec.o mbedtls.o libecc.o openssl.o gcrypt.o cryptopp.o nettle.o -o $OUT/fuzz_ec ../mbedtls/library/libmbedcrypto.a ../libecc/build/libec.a ../libecc/src/external_deps/rand.o ../openssl/libcrypto.a ../nettle/libhogweed.a ../nettle/libnettle.a ../nettle/gmp-6.1.2/.libs/libgmp.a ../gcrypt/src/.libs/libgcrypt.a ../cryptopp/libcryptopp.a -lgpg-error $LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS fuzz_ec.o mbedtls.o libecc.o openssl.o gcrypt.o cryptopp.o nettle.o -o $OUT/fuzz_ec ../mbedtls/crypto/library/libmbedcrypto.a ../libecc/build/libec.a ../libecc/src/external_deps/rand.o ../openssl/libcrypto.a ../nettle/libhogweed.a ../nettle/libnettle.a ../nettle/gmp-6.1.2/.libs/libgmp.a ../gcrypt/src/.libs/libgcrypt.a ../cryptopp/libcryptopp.a -lgpg-error $LIB_FUZZING_ENGINE

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -11,3 +11,5 @@ sanitizers:
 
 fuzzing_engines:
   - afl
+
+disabled: True

--- a/projects/giflib/egif_fuzz_common.cc
+++ b/projects/giflib/egif_fuzz_common.cc
@@ -1,12 +1,13 @@
 #include "egif_fuzz_common.h"
-
-//using namespace std;
+#define GIF_IMAGE_WIDTH  100
+// This is rgb byte stream length per horizontal line = GIF_IMAGE_WIDTH * 3
+#define GIF_IMAGE_LINE   300
 
 extern "C" void PrintGifError(int ErrorCode);
 
-int stub_output_writer(GifFileType *gifFileType, const uint8_t *buf, int len)
+int stub_output_writer(GifFileType* gifFileType, const uint8_t* buf, int len)
 {
-	struct gifUserData *gud = (struct gifUserData *)gifFileType->UserData;
+	struct gifUserData* gud = (struct gifUserData*) gifFileType->UserData;
 
 	if (gud == NULL || gud->gifData == NULL || len == 0)
 		return 0;
@@ -17,23 +18,173 @@ int stub_output_writer(GifFileType *gifFileType, const uint8_t *buf, int len)
 	return len;
 }
 
-int fuzz_egif(const uint8_t *Data, size_t Size)
+// RGB to GIF converter
+static
+bool rgb_to_gif(const uint8_t* data, size_t size)
 {
-	GifFileType *GifFile;
-	int Error;
-	uint8_t *gifData = (uint8_t *)malloc(Size);
-	memcpy(gifData, Data, Size);
-	struct gifUserData gUData = {Size, gifData};
+	// Bail if total size is not a multiple of GIF_IMAGE_LINE (see below)
+	// Keep a fixed width e.g., GIF_IMAGE_WIDTH
+	// size/3 = GIF_IMAGE_WIDTH * height
+	// height = size/GIF_IMAGE_LINE
 
-	GifFile = EGifOpen((void *)&gUData, stub_output_writer, &Error);
-	if (GifFile == NULL)
-	{
-		PrintGifError(GifFile->Error);
-		free(gifData);
-		return 0;
+	// Extract height
+	int height = size / GIF_IMAGE_LINE;
+
+	// GifByteType is unsigned char (raw byte)
+	// mem holds the raw RGB byte stream for the entire image
+	GifByteType* mem = (GifByteType*) malloc(sizeof(GifByteType) * height * GIF_IMAGE_WIDTH * 3);
+	if (!mem)
+		return false;
+
+	// Copy RGB data to mem
+	memcpy(mem, data, size);
+
+	GifByteType* red_buf = mem;
+	GifByteType* green_buf = mem + (GIF_IMAGE_WIDTH * height);
+	GifByteType* blue_buf = mem + (GIF_IMAGE_WIDTH * height * 2);
+
+	// ColorMapObject *GifMakeMapObject(int ColorCount, GifColorType *ColorMap)
+	// Allocate storage for a color map object with the given number of RGB triplet slots.
+	// If the second argument is non-NULL, initialize the color table portion of
+	// the new map from it. Returns NULL if memory is exhausted or if the size is
+	// not a power of 2 <= 256.
+	// TODO: Fuzz color map size (has to be a power of 2 less than equal to 256)
+	// TODO: Fuzz color table initialization
+	int color_map_size = 256;
+	ColorMapObject* output_color_map = GifMakeMapObject(color_map_size, NULL);
+	if (!output_color_map) {
+		free(mem);
+		return false;
 	}
 
+	// gif output will be written to output_buf
+	size_t out_size = sizeof(GifByteType) * GIF_IMAGE_WIDTH * height;
+	GifByteType* output_buf = (GifByteType*) malloc(out_size);
+	if (!output_buf) {
+		GifFreeMapObject(output_color_map);
+		free(mem);
+		return false;
+	}
+
+	if (GifQuantizeBuffer(GIF_IMAGE_WIDTH, height, &color_map_size,
+	                      red_buf, green_buf, blue_buf,
+	                      output_buf, output_color_map->Colors) == GIF_ERROR) {
+		GifFreeMapObject(output_color_map);
+		free(output_buf);
+		free(mem);
+		return false;
+	}
+
+	// Now that raw RGB data has been quantized, we no longer need it.
+	free(mem);
+
+	GifFileType* GifFile;
+	int Error;
+	// FIXME: How big should the gif data buffer be?
+	// 4096 is just a heuristic
+	// 256 * 3 = 768 (color data)
+	// raw bytes = out_size
+	uint8_t* gifData = (uint8_t*) malloc(4096);
+	struct gifUserData gUData = {4096, gifData};
+
+	/* GifFileType *EGifOpen(void *userPtr, OutputFunc writeFunc, int *ErrorCode)
+	 * Description:
+	 *  Open a new GIF file using the given userPtr (in binary mode, if under Windows).
+	 *  writeFunc is a function pointer that writes to output gif file.
+	 *  If any error occurs, NULL is returned and the ErrorCode is set.
+	 */
+	GifFile = EGifOpen((void*) &gUData, stub_output_writer, &Error);
+	if (GifFile == NULL) {
+		PrintGifError(GifFile->Error);
+		GifFreeMapObject(output_color_map);
+		free(output_buf);
+		free(gifData);
+		return false;
+	}
+
+	/* void EGifSetGifVersion(GifFileType *GifFile, bool gif89)
+	 * Description:
+	 * 	Set the GIF type, to GIF89 if the argument is true and GIF87 if it is false.
+	 * 	The default type is GIF87. This function may be called after the GifFile
+	 * 	record is allocated but before EGifPutScreenDesc().
+	 */
+	EGifSetGifVersion(GifFile, false);
+
+	/* int EGifPutScreenDesc(GifFileType *GifFile,
+     *   const int GifWidth, const GifHeight,
+     *   const int GifColorRes, const int GifBackGround,
+     *   ColorMapObject *GifColorMap)
+     *
+	 *  Update the GifFile Screen parameters, in GifFile structure and in the real file.
+	 *  If error occurs, returns GIF_ERROR (see gif_lib.h), otherwise GIF_OK.
+	 * 	This routine should be called immediately after the GIF file was opened.
+	 */
+	if (EGifPutScreenDesc(GifFile, GIF_IMAGE_WIDTH, height, color_map_size, 0, output_color_map)
+	    == GIF_ERROR) {
+		PrintGifError(GifFile->Error);
+		GifFreeMapObject(output_color_map);
+		free(output_buf);
+		EGifCloseFile(GifFile, &Error);
+		free(gifData);
+		return false;
+	}
+
+	/* int EGifPutImageDesc(GifFileType *GifFile, const int GifLeft, const int GifTop,
+	 * const int GifWidth, const GifHeight, const bool GifInterlace, ColorMapObject *GifColorMap)
+	 * Description
+	 *  Update GifFile Image parameters, in GifFile structure and in the real file.
+	 *  if error occurs returns GIF_ERROR (see gif_lib.h), otherwise GIF_OK.
+	 *  This routine should be called each time a new image must be dumped to the file.
+	 */
+	if (EGifPutImageDesc(GifFile, 0, 0, GIF_IMAGE_WIDTH, height, false, NULL) == GIF_ERROR) {
+		PrintGifError(GifFile->Error);
+		GifFreeMapObject(output_color_map);
+		free(output_buf);
+		EGifCloseFile(GifFile, &Error);
+		free(gifData);
+		return false;
+	}
+
+	GifByteType* output_bufp = output_buf;
+	for (int i = 0; i < height; i++) {
+		/* int EGifPutLine(GifFileType *GifFile, PixelType *GifLine, int GifLineLen)
+		 * Description:
+		 *  Dumps a block of pixels out to the GIF file. The slab can be of any length.
+		 *  More than that, this routine may be interleaved with EGifPutPixel(),
+		 *  until all pixels have been sent.
+		 *  Returns GIF_ERROR if something went wrong, GIF_OK otherwise.
+		 */
+		if (EGifPutLine(GifFile, output_bufp, GIF_IMAGE_WIDTH) == GIF_ERROR) {
+			PrintGifError(GifFile->Error);
+			GifFreeMapObject(output_color_map);
+			free(output_buf);
+			EGifCloseFile(GifFile, &Error);
+			free(gifData);
+			return false;
+		}
+		output_bufp += GIF_IMAGE_WIDTH;
+	}
+
+	/* void GifFreeMapObject(ColorMapObject *Object)
+	 * Description
+	 *  Free the storage occupied by a ColorMapObject that is no longer needed.
+	 */
+	GifFreeMapObject(output_color_map);
+	free(output_buf);
 	EGifCloseFile(GifFile, &Error);
 	free(gifData);
+	return true;
+}
+
+int fuzz_egif(const uint8_t* Data, size_t Size)
+{
+	// We treat fuzzed data as a raw RGB stream for a picture
+	// with a fixed width of GIF_IMAGE_WIDTH.
+	// Since we need 3 color bytes per pixel (RGB), height = size/GIF_IMAGE_LINE
+	//      where GIF_IMAGE_LINE = GIF_IMAGE_WIDTH * 3
+	// For integral height, we need Size to be a multiple of GIF_IMAGE_LINE
+	if ((Size == 0) || ((Size % GIF_IMAGE_LINE) != 0))
+		return 0;
+	bool status = rgb_to_gif(Data, Size);
 	return 0;
 }

--- a/projects/gnupg/project.yaml
+++ b/projects/gnupg/project.yaml
@@ -1,4 +1,2 @@
 homepage: "https://www.gnupg.org"
 primary_contact: "p.antoine@catenacyber.fr"
-fuzzing_engines:
-  - libfuzzer

--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -11,6 +11,7 @@ auto_ccs:
   - "jfkthame@gmail.com"
   - "cchapman@adobe.com"
   - "ariza@typekit.com"
+  - "qxliu@google.com"
 sanitizers:
  - address
  - undefined

--- a/projects/hostap/build.sh
+++ b/projects/hostap/build.sh
@@ -60,7 +60,7 @@ export CFLAGS="$CFLAGS -DTEST_LIBFUZZER -DCONFIG_NO_STDOUT_DEBUG"
 
 for target in json x509; do
   make test-${target} TEST_FUZZ=y
-  cp -v "test-${target}" "${OUT}/"
+  mv -v "test-${target}" "${OUT}/"
 done
 
 # AFL compatible targets --------------------------------------------------
@@ -95,13 +95,13 @@ export CFLAGS="$CFLAGS -Dmain=fuzzer_main"
   make clean
   CFLAGS="$CFLAGS -DEXTRA_ARGS='\"-m\",'" \
     make -C "ap-mgmt-fuzzer"
-  cp -v "ap-mgmt-fuzzer/ap-mgmt-fuzzer" "${OUT}/"
+  mv -v "ap-mgmt-fuzzer/ap-mgmt-fuzzer" "${OUT}/"
 
   # wnm-fuzzer
   patch_afl_fuzzer "wnm-fuzzer/wnm-fuzzer.c"
   rm -v "libfuzzer_entry.o"
   make -C "wnm-fuzzer"
-  cp -v "wnm-fuzzer/wnm-fuzzer" "${OUT}/"
+  mv -v "wnm-fuzzer/wnm-fuzzer" "${OUT}/"
 
   # TODO: Investigate leak and remove if not false positive.
   print_ignore_leaks_options > "${OUT}/wnm-fuzzer.options"
@@ -126,23 +126,23 @@ recompile_libfuzzer_entry() {
   CFLAGS="$CFLAGS -DEXTRA_ARGS=\"server\",\"read\"," \
     recompile_libfuzzer_entry
   make test-tls TEST_FUZZ=y
-  cp -v "test-tls" "${OUT}/test-tls-server-read"
+  mv -v "test-tls" "${OUT}/test-tls-server-read"
 
   CFLAGS="$CFLAGS -DEXTRA_ARGS=\"client\",\"read\"," \
     recompile_libfuzzer_entry
   make test-tls TEST_FUZZ=y
-  cp -v "test-tls" "${OUT}/test-tls-client-read"
+  mv -v "test-tls" "${OUT}/test-tls-client-read"
 )
 
 (
-  export LIBS="../libfuzzer_entry.o"
+  export LDFLAGS="$LDFLAGS ../libfuzzer_entry.o"
 
   # eapol-fuzzer
   patch_afl_fuzzer "eapol-fuzzer/eapol-fuzzer.c"
   make -C "eapol-fuzzer" clean
   recompile_libfuzzer_entry
   make -C "eapol-fuzzer"
-  cp -v "eapol-fuzzer/eapol-fuzzer" "${OUT}/"
+  mv -v "eapol-fuzzer/eapol-fuzzer" "${OUT}/"
 
   # p2p-fuzzer variants
   patch_afl_fuzzer "p2p-fuzzer/p2p-fuzzer.c"
@@ -150,11 +150,11 @@ recompile_libfuzzer_entry() {
   CFLAGS="$CFLAGS -DEXTRA_ARGS=\"action\"," \
     recompile_libfuzzer_entry
   make -C "p2p-fuzzer"
-  cp -v "p2p-fuzzer/p2p-fuzzer" "${OUT}/p2p-fuzzer-action"
+  mv -v "p2p-fuzzer/p2p-fuzzer" "${OUT}/p2p-fuzzer-action"
   CFLAGS="$CFLAGS -DEXTRA_ARGS=\"proberesp\"," \
     recompile_libfuzzer_entry
   make -C "p2p-fuzzer"
-  cp -v "p2p-fuzzer/p2p-fuzzer" "${OUT}/p2p-fuzzer-proberesp"
+  mv -v "p2p-fuzzer/p2p-fuzzer" "${OUT}/p2p-fuzzer-proberesp"
 )
 
 # Copy required data.

--- a/projects/icu/build.sh
+++ b/projects/icu/build.sh
@@ -33,17 +33,17 @@ export UBSAN_OPTIONS="detect_leaks=0"
 
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -c $SRC/icu/icu4c/source/test/fuzzer/locale_util.cc \
+$CXX $CXXFLAGS -std=c++11 -c $SRC/icu/icu4c/source/test/fuzzer/locale_util.cpp \
      -I$SRC/icu4c/source/test/fuzzer
 
 FUZZER_PATH=$SRC/icu/icu4c/source/test/fuzzer
-# Assumes that all fuzzers files end with'_fuzzer.cc'.
-FUZZERS=$FUZZER_PATH/*_fuzzer.cc
+# Assumes that all fuzzers files end with'_fuzzer.cpp'.
+FUZZERS=$FUZZER_PATH/*_fuzzer.cpp
 
 for fuzzer in $FUZZERS; do
   file=${fuzzer:${#FUZZER_PATH}+1}
   $CXX $CXXFLAGS -std=c++11 \
-    $fuzzer -o $OUT/${file/.cc/} locale_util.o \
+    $fuzzer -o $OUT/${file/.cpp/} locale_util.o \
     -I$SRC/icu/icu4c/source/common -I$SRC/icu/icu4c/source/i18n -L$WORK/icu/lib \
     $LIB_FUZZING_ENGINE -licui18n -licuuc -licutu -licudata
 done

--- a/projects/jsc/build.sh
+++ b/projects/jsc/build.sh
@@ -36,6 +36,7 @@ ln -s libicu.a libicui18n.a
 
 export CFLAGS="$CFLAGS -DU_STATIC_IMPLEMENTATION"
 export CXXFLAGS="$CXXFLAGS -DU_STATIC_IMPLEMENTATION"
+export ICU_ROOT=$DEPS_PATH
 
 cd $SRC/WebKit
 Tools/Scripts/build-jsc \

--- a/projects/libfmt/Dockerfile
+++ b/projects/libfmt/Dockerfile
@@ -20,7 +20,11 @@ RUN echo "CXX=$CXX"
 RUN echo "CXXFLAGS=$CXXFLAGS"
 RUN apt-get update && apt-get install -y cmake ninja-build
 
-RUN git clone --single-branch --branch fuzz https://github.com/pauldreik/fmt.git
+RUN git clone --single-branch --branch fuzz \
+  https://github.com/pauldreik/fmt.git \
+  --recursive
+# this requires git>=2.9.0
+#--shallow-submodules
 
 WORKDIR fmt
 COPY build.sh $SRC/

--- a/projects/libfmt/build.sh
+++ b/projects/libfmt/build.sh
@@ -23,9 +23,16 @@
 mkdir build
 cd build
 
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug \
+# use C++ 14 instead of 17, because even if clang is
+# bleeding edge, cmake is old in the oss fuzz image.
+
+cmake .. \
+-GNinja \
+-DCMAKE_BUILD_TYPE=Debug \
+-DCMAKE_CXX_STANDARD=14 \
 -DFMT_DOC=Off \
 -DFMT_TEST=Off \
+-DFMT_SAFE_DURATION_CAST=On \
 -DFMT_FUZZ=On \
 -DFMT_FUZZ_LINKMAIN=Off \
 -DFMT_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE

--- a/projects/libfmt/project.yaml
+++ b/projects/libfmt/project.yaml
@@ -3,4 +3,3 @@ primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "victor.zverovich@gmail.com"
 
-

--- a/projects/mbedtls/Dockerfile
+++ b/projects/mbedtls/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 #TODO change
 MAINTAINER support-mbedtls@arm.com
 RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
+RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl
 RUN git clone --depth 1 https://github.com/openssl/openssl.git openssl
 WORKDIR mbedtls

--- a/projects/mbedtls/build.sh
+++ b/projects/mbedtls/build.sh
@@ -47,5 +47,5 @@ for target in x509crl x509crt x509csr privkey pubkey client server dtlsclient dt
 do
     $CC $CFLAGS -I. -I ../../include -c fuzz_$target.c -o fuzz_$target.o
 
-    $CXX $CXXFLAGS -std=c++11 fuzz_$target.o -o $OUT/fuzz_$target ../../library/libmbedx509.a ../../library/libmbedtls.a ../../library/libmbedcrypto.a $LIB_FUZZING_ENGINE
+    $CXX $CXXFLAGS -std=c++11 fuzz_$target.o -o $OUT/fuzz_$target ../../library/libmbedx509.a ../../library/libmbedtls.a ../../crypto/library/libmbedcrypto.a $LIB_FUZZING_ENGINE
 done

--- a/projects/readstat/build.sh
+++ b/projects/readstat/build.sh
@@ -32,6 +32,11 @@ zip $OUT/fuzz_format_sas7bdat_seed_corpus.zip corpus/sas7bdat*/test-case-*
 zip $OUT/fuzz_format_xport_seed_corpus.zip corpus/xpt*/test-case-*
 
 READSTAT_FUZZERS="
+    fuzz_compression_sav \
+    fuzz_grammar_spss_format \
+    fuzz_format_sas_commands \
+    fuzz_format_spss_commands \
+    fuzz_format_stata_dictionary \
     fuzz_format_dta \
     fuzz_format_por \
     fuzz_format_sav \


### PR DESCRIPTION
This PR extends the gif encoder fuzzer harness by
  - treating the fuzzer input as an RGB stream and encoding this into a Gif file
  - TODO: How much space to allocate for the encoded gif file buffer? Can this be pre-computed?
     - Allocating a hard-coded size of 4KB (4096 bytes) but I'm afraid this might overshoot the limit and mask potential buffer overwrites in the gif library.