### PR TITLE
stub_output_writer now dynamically reallocates memory

### DIFF
--- a/projects/giflib/egif_fuzz_common.cc
+++ b/projects/giflib/egif_fuzz_common.cc
@@ -17,11 +17,8 @@ int stub_output_writer(GifFileType *gifFileType, const uint8_t *buf, int len)
 		int newSize = (gud->gifLen + len) * 2;
 		uint8_t *oldGud = gud->gifData;
 		gud->gifData = (uint8_t *)realloc(oldGud, newSize);
-		if (gud->gifData == NULL)
-		{
-			gud->gifData = oldGud;
-			return 0;
-		}
+		// Assert when realloc fails.
+		assert(gud->gifData != NULL);
 		gud->allocatedSize = newSize;
 	}
 	memcpy(gud->gifData + gud->gifLen, buf, len);

--- a/projects/giflib/egif_fuzz_common.cc
+++ b/projects/giflib/egif_fuzz_common.cc
@@ -1,26 +1,36 @@
 #include "egif_fuzz_common.h"
-#define GIF_IMAGE_WIDTH  100
+#define GIF_IMAGE_WIDTH 100
 // This is rgb byte stream length per horizontal line = GIF_IMAGE_WIDTH * 3
-#define GIF_IMAGE_LINE   300
+#define GIF_IMAGE_LINE 300
 
 extern "C" void PrintGifError(int ErrorCode);
 
-int stub_output_writer(GifFileType* gifFileType, const uint8_t* buf, int len)
+int stub_output_writer(GifFileType *gifFileType, const uint8_t *buf, int len)
 {
-	struct gifUserData* gud = (struct gifUserData*) gifFileType->UserData;
+	struct gifUserData *gud = (struct gifUserData *)gifFileType->UserData;
 
 	if (gud == NULL || gud->gifData == NULL || len == 0)
 		return 0;
-
-	memcpy(gud->gifData, buf, len);
-	gud->gifData += len;
+	if (gud->allocatedSize < (gud->gifLen + len))
+	{
+		// Reallocate gifFileType
+		int newSize = gud->allocatedSize * 2;
+		uint8_t *oldGud = gud->gifData;
+		gud->gifData = (uint8_t *)realloc(oldGud, newSize);
+		if (gud->gifData == NULL)
+		{
+			gud->gifData = oldGud;
+			return 0;
+		}
+		gud->allocatedSize = newSize;
+	}
+	memcpy(gud->gifData + gud->gifLen, buf, len);
 	gud->gifLen += len;
 	return len;
 }
 
 // RGB to GIF converter
-static
-bool rgb_to_gif(const uint8_t* data, size_t size)
+static bool rgb_to_gif(const uint8_t *data, size_t size)
 {
 	// Bail if total size is not a multiple of GIF_IMAGE_LINE (see below)
 	// Keep a fixed width e.g., GIF_IMAGE_WIDTH
@@ -32,16 +42,16 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 
 	// GifByteType is unsigned char (raw byte)
 	// mem holds the raw RGB byte stream for the entire image
-	GifByteType* mem = (GifByteType*) malloc(sizeof(GifByteType) * height * GIF_IMAGE_WIDTH * 3);
+	GifByteType *mem = (GifByteType *)malloc(sizeof(GifByteType) * height * GIF_IMAGE_WIDTH * 3);
 	if (!mem)
 		return false;
 
 	// Copy RGB data to mem
 	memcpy(mem, data, size);
 
-	GifByteType* red_buf = mem;
-	GifByteType* green_buf = mem + (GIF_IMAGE_WIDTH * height);
-	GifByteType* blue_buf = mem + (GIF_IMAGE_WIDTH * height * 2);
+	GifByteType *red_buf = mem;
+	GifByteType *green_buf = mem + (GIF_IMAGE_WIDTH * height);
+	GifByteType *blue_buf = mem + (GIF_IMAGE_WIDTH * height * 2);
 
 	// ColorMapObject *GifMakeMapObject(int ColorCount, GifColorType *ColorMap)
 	// Allocate storage for a color map object with the given number of RGB triplet slots.
@@ -51,24 +61,27 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	// TODO: Fuzz color map size (has to be a power of 2 less than equal to 256)
 	// TODO: Fuzz color table initialization
 	int color_map_size = 256;
-	ColorMapObject* output_color_map = GifMakeMapObject(color_map_size, NULL);
-	if (!output_color_map) {
+	ColorMapObject *output_color_map = GifMakeMapObject(color_map_size, NULL);
+	if (!output_color_map)
+	{
 		free(mem);
 		return false;
 	}
 
 	// gif output will be written to output_buf
 	size_t out_size = sizeof(GifByteType) * GIF_IMAGE_WIDTH * height;
-	GifByteType* output_buf = (GifByteType*) malloc(out_size);
-	if (!output_buf) {
+	GifByteType *output_buf = (GifByteType *)malloc(out_size);
+	if (!output_buf)
+	{
 		GifFreeMapObject(output_color_map);
 		free(mem);
 		return false;
 	}
 
 	if (GifQuantizeBuffer(GIF_IMAGE_WIDTH, height, &color_map_size,
-	                      red_buf, green_buf, blue_buf,
-	                      output_buf, output_color_map->Colors) == GIF_ERROR) {
+						  red_buf, green_buf, blue_buf,
+						  output_buf, output_color_map->Colors) == GIF_ERROR)
+	{
 		GifFreeMapObject(output_color_map);
 		free(output_buf);
 		free(mem);
@@ -78,14 +91,12 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	// Now that raw RGB data has been quantized, we no longer need it.
 	free(mem);
 
-	GifFileType* GifFile;
+	GifFileType *GifFile;
 	int Error;
-	// FIXME: How big should the gif data buffer be?
-	// 4096 is just a heuristic
-	// 256 * 3 = 768 (color data)
-	// raw bytes = out_size
-	uint8_t* gifData = (uint8_t*) malloc(4096);
-	struct gifUserData gUData = {4096, gifData};
+	// We start with 1024, but resize dynamically
+	// see stub_output_writer
+	uint8_t *gifData = (uint8_t *)malloc(1024);
+	struct gifUserData gUData = {0, 1024, gifData};
 
 	/* GifFileType *EGifOpen(void *userPtr, OutputFunc writeFunc, int *ErrorCode)
 	 * Description:
@@ -93,12 +104,13 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	 *  writeFunc is a function pointer that writes to output gif file.
 	 *  If any error occurs, NULL is returned and the ErrorCode is set.
 	 */
-	GifFile = EGifOpen((void*) &gUData, stub_output_writer, &Error);
-	if (GifFile == NULL) {
+	GifFile = EGifOpen((void *)&gUData, stub_output_writer, &Error);
+	if (GifFile == NULL)
+	{
 		PrintGifError(GifFile->Error);
 		GifFreeMapObject(output_color_map);
 		free(output_buf);
-		free(gifData);
+		free(gUData.gifData);
 		return false;
 	}
 
@@ -119,13 +131,13 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	 *  If error occurs, returns GIF_ERROR (see gif_lib.h), otherwise GIF_OK.
 	 * 	This routine should be called immediately after the GIF file was opened.
 	 */
-	if (EGifPutScreenDesc(GifFile, GIF_IMAGE_WIDTH, height, color_map_size, 0, output_color_map)
-	    == GIF_ERROR) {
+	if (EGifPutScreenDesc(GifFile, GIF_IMAGE_WIDTH, height, color_map_size, 0, output_color_map) == GIF_ERROR)
+	{
 		PrintGifError(GifFile->Error);
 		GifFreeMapObject(output_color_map);
 		free(output_buf);
 		EGifCloseFile(GifFile, &Error);
-		free(gifData);
+		free(gUData.gifData);
 		return false;
 	}
 
@@ -136,17 +148,19 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	 *  if error occurs returns GIF_ERROR (see gif_lib.h), otherwise GIF_OK.
 	 *  This routine should be called each time a new image must be dumped to the file.
 	 */
-	if (EGifPutImageDesc(GifFile, 0, 0, GIF_IMAGE_WIDTH, height, false, NULL) == GIF_ERROR) {
+	if (EGifPutImageDesc(GifFile, 0, 0, GIF_IMAGE_WIDTH, height, false, NULL) == GIF_ERROR)
+	{
 		PrintGifError(GifFile->Error);
 		GifFreeMapObject(output_color_map);
 		free(output_buf);
 		EGifCloseFile(GifFile, &Error);
-		free(gifData);
+		free(gUData.gifData);
 		return false;
 	}
 
-	GifByteType* output_bufp = output_buf;
-	for (int i = 0; i < height; i++) {
+	GifByteType *output_bufp = output_buf;
+	for (int i = 0; i < height; i++)
+	{
 		/* int EGifPutLine(GifFileType *GifFile, PixelType *GifLine, int GifLineLen)
 		 * Description:
 		 *  Dumps a block of pixels out to the GIF file. The slab can be of any length.
@@ -154,12 +168,13 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 		 *  until all pixels have been sent.
 		 *  Returns GIF_ERROR if something went wrong, GIF_OK otherwise.
 		 */
-		if (EGifPutLine(GifFile, output_bufp, GIF_IMAGE_WIDTH) == GIF_ERROR) {
+		if (EGifPutLine(GifFile, output_bufp, GIF_IMAGE_WIDTH) == GIF_ERROR)
+		{
 			PrintGifError(GifFile->Error);
 			GifFreeMapObject(output_color_map);
 			free(output_buf);
 			EGifCloseFile(GifFile, &Error);
-			free(gifData);
+			free(gUData.gifData);
 			return false;
 		}
 		output_bufp += GIF_IMAGE_WIDTH;
@@ -172,11 +187,11 @@ bool rgb_to_gif(const uint8_t* data, size_t size)
 	GifFreeMapObject(output_color_map);
 	free(output_buf);
 	EGifCloseFile(GifFile, &Error);
-	free(gifData);
+	free(gUData.gifData);
 	return true;
 }
 
-int fuzz_egif(const uint8_t* Data, size_t Size)
+int fuzz_egif(const uint8_t *Data, size_t Size)
 {
 	// We treat fuzzed data as a raw RGB stream for a picture
 	// with a fixed width of GIF_IMAGE_WIDTH.

--- a/projects/giflib/egif_fuzz_common.cc
+++ b/projects/giflib/egif_fuzz_common.cc
@@ -14,7 +14,7 @@ int stub_output_writer(GifFileType *gifFileType, const uint8_t *buf, int len)
 	if (gud->allocatedSize < (gud->gifLen + len))
 	{
 		// Reallocate gifFileType
-		int newSize = gud->allocatedSize * 2;
+		int newSize = (gud->gifLen + len) * 2;
 		uint8_t *oldGud = gud->gifData;
 		gud->gifData = (uint8_t *)realloc(oldGud, newSize);
 		if (gud->gifData == NULL)

--- a/projects/giflib/egif_fuzz_common.h
+++ b/projects/giflib/egif_fuzz_common.h
@@ -6,6 +6,7 @@
 struct gifUserData
 {
 	size_t gifLen;
+	size_t allocatedSize;
 	uint8_t *gifData;
 };
 

--- a/projects/giflib/egif_fuzz_common.h
+++ b/projects/giflib/egif_fuzz_common.h
@@ -1,4 +1,5 @@
 #include "gif_lib.h"
+#include "assert.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Memory allocation for stub_output_writer is now dynamic:
gifData will be reallocated in base 2 steps every time
we need more space.