### PR TITLE
Fix build failure for giflib

### DIFF
--- a/projects/giflib/egif_fuzz_common.h
+++ b/projects/giflib/egif_fuzz_common.h
@@ -11,5 +11,11 @@ struct gifUserData
 	uint8_t *gifData;
 };
 
+extern "C" int GifQuantizeBuffer(unsigned int Width, unsigned int Height,
+                   int *ColorMapSize, GifByteType * RedInput,
+                   GifByteType * GreenInput, GifByteType * BlueInput,
+                   GifByteType * OutputBuffer,
+                   GifColorType * OutputColorMap);
+
 int stub_output_writer(GifFileType *gifFileType, GifByteType *gifByteType, int len);
 int fuzz_egif(const uint8_t *Data, size_t Size);


### PR DESCRIPTION
This commit fixes the current build failure for giflib
by adding GifQuantizeBuffer into the fuzzer's header file.